### PR TITLE
adding an api to check gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,37 @@
 [Ready4Rails.net](http://www.ready4rails.net) lists many gems and shows whether they are ready
 for Rails 4 or 5. You can also paste your Gemfile to get a one-click report of the status of your Gemfile gems.
 
+## API (Beta)
+
+[Ready4Rails.net](http://www.ready4rails.net) gives an API to programatically check if a given
+gem is ready for Rails 4 or 5. (Please note this feature is still in beta and can be changed in future)
+
+Syntax
+-----------
+
+Request (GET)
+
+```ruby
+http://ready4rails.net/gems/<gem name>
+```
+
+response
+```ruby
+  JSON object with gem details
+```
+
+E.g:
+
+```ruby
+#request (GET)
+
+http://localhost:3000/gems/devise.json
+
+#response
+{"id":1,"name":"devise","status_rails4":"ready","notes_rails4":"ready","created_at":"2015-12-01T23:02:37.019Z","updated_at":"2015-12-01T23:02:37.019Z","status_rails5":"unknown","notes_rails5":""}
+```
+
+
 ## Thanks to
 
 * all the people who report new gem statuses and add new gems to the site

--- a/app/controllers/rubygems_controller.rb
+++ b/app/controllers/rubygems_controller.rb
@@ -1,4 +1,5 @@
 class RubygemsController < ApplicationController
+
   def index
     @status        = params[:status]
     @rails_version = params[:rails_version]
@@ -21,6 +22,10 @@ class RubygemsController < ApplicationController
   def show
     @gem = Rubygem.find_by_name params[:id]
     fresh_when @gem, public: true
+    respond_to do |format|
+      format.html
+      format.json { render :json => (@gem || {})  }
+    end
   end
 
   def new

--- a/spec/controllers/rubygems_controller_spec.rb
+++ b/spec/controllers/rubygems_controller_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe RubygemsController, type: :controller do
+
+  before(:each) do
+    allow_any_instance_of(Rubygem).to receive(:gem_exists_in_rubygem_dot_org).and_return(true)
+  end
+
+  describe 'api' do
+    let!(:devise) { FactoryGirl.create :rubygem, status_rails4: 'ready', status_rails5: 'unknown' }
+
+    context 'when checking for a valid gem' do
+      it 'should return json with details' do
+        get :show, id: devise.name, format: :json
+        expect(response.status).to eq 200
+        hash = JSON.parse(response.body)
+        expect(hash['name']).to eq(devise.name)
+        expect(hash['status_rails4']).to eq('ready')
+        expect(hash['status_rails5']).to eq('unknown')
+        expect(hash['notes_rails4']).to eq(devise.notes_rails4)
+        expect(hash['notes_rails5']).to eq(devise.notes_rails5)
+      end
+    end
+
+    context "when checking for an invalid gem" do
+      it 'should return empty json' do
+        get :show, id: 'some other name', format: :json
+        expect(response.status).to eq 200
+        hash = JSON.parse(response.body)
+        expect(hash).to be_truthy
+      end
+    end
+  end
+end
+


### PR DESCRIPTION
## API (Beta)

adding an API to programatically check if a given
gem is ready for Rails 4 or 5. (Please note this feature is still in beta and can be changed in future)
## Syntax

Request (GET)

``` ruby
http://ready4rails.net/gems/<gem name>
```

response

``` ruby
  JSON object with gem details
```
